### PR TITLE
Correct filename case in #include directive

### DIFF
--- a/Zmotor3.cpp
+++ b/Zmotor3.cpp
@@ -5,7 +5,7 @@ Inspired from Adafruit 16-channel PWM & Servo driver library
 
 
 */
-#include "zmotor3.h"
+#include "Zmotor3.h"
 
 #include <Wire.h>
 


### PR DESCRIPTION
Incorrect capitalization of Zmotor3.h causes compilation to fail on filename case-sensitive operating systems like Linux.